### PR TITLE
Add support for Ubuntu and Debian `batcat` naming

### DIFF
--- a/zsh-bat.plugin.zsh
+++ b/zsh-bat.plugin.zsh
@@ -1,6 +1,17 @@
 
-if command -v bat >/dev/null 2>&1; then
+if command -v batcat >/dev/null 2>&1; then
+  # Save the original system `cat` under `rcat`
   alias rcat=$(which cat)
+
+  # For Ubuntu and Debian-based `bat` packages
+  # the `bat` program is named `batcat` on these systems
+  alias cat=$(which batcat)
+  export MANPAGER="sh -c 'col -bx | batcat -l man -p'"
+elif command -v bat >/dev/null 2>&1; then
+  # Save the original system `cat` under `rcat`
+  alias rcat=$(which cat)
+
+  # For all other systems
   alias cat=$(which bat)
   export MANPAGER="sh -c 'col -bx | bat -l man -p'"
 fi


### PR DESCRIPTION
This branch supports the `batcat` name assigned to `bat` in [Ubuntu][ubuntu-deb-files] and other Debian-based systems. 

[ubuntu-deb-files]: https://packages.ubuntu.com/focal/amd64/bat/filelist