### PR TITLE
Fixed aliases

### DIFF
--- a/zsh-bat.plugin.zsh
+++ b/zsh-bat.plugin.zsh
@@ -1,17 +1,17 @@
 
 if command -v batcat >/dev/null 2>&1; then
   # Save the original system `cat` under `rcat`
-  alias rcat=$(which cat)
+  alias rcat="$(which cat)"
 
   # For Ubuntu and Debian-based `bat` packages
   # the `bat` program is named `batcat` on these systems
-  alias cat=$(which batcat)
+  alias cat="$(which batcat)"
   export MANPAGER="sh -c 'col -bx | batcat -l man -p'"
 elif command -v bat >/dev/null 2>&1; then
   # Save the original system `cat` under `rcat`
-  alias rcat=$(which cat)
+  alias rcat="$(which cat)"
 
   # For all other systems
-  alias cat=$(which bat)
+  alias cat="$(which bat)"
   export MANPAGER="sh -c 'col -bx | bat -l man -p'"
 fi


### PR DESCRIPTION
The plugin does not work on my computer. Using `alias` without quotes means that the output of `$(which cat)`, for example, will be parsed in an unexpected manner. For example, if there is a space in the path to `cat` or `bat`, it will not be treated as a full path, but rather multiple arguments, and therefore will not work. 

Encapsulating the output of `$(which cat)`, for example, in quotes ensures that the full path is considered, even if it has spaces. My modified version works on my computer.

